### PR TITLE
Fix iOS occasionally not showing barcode scanner.

### DIFF
--- a/src/Acr.BarCodes.iOS/BarCodesImpl.cs
+++ b/src/Acr.BarCodes.iOS/BarCodesImpl.cs
@@ -42,31 +42,16 @@ namespace Acr.BarCodes {
         }
 
 
-		protected virtual UIWindow GetTopWindow() {
-			return UIApplication.SharedApplication
-				.Windows
-				.Reverse()
-				.FirstOrDefault(x =>
-					x.WindowLevel == UIWindowLevel.Normal &&
-					!x.Hidden
-				);
-		}
-
-
 		protected virtual UIViewController GetTopViewController() {
-			var root = this.GetTopWindow().RootViewController;
-			var tabs = root as UITabBarController;
-			if (tabs != null)
-				return tabs.PresentedViewController ?? tabs.SelectedViewController;
+            var window = UIApplication.SharedApplication.KeyWindow;
+            var vc = window.RootViewController;
 
-			var nav = root as UINavigationController;
-			if (nav != null)
-				return nav.VisibleViewController;
+            while (vc.PresentedViewController != null)
+            {
+                vc = vc.PresentedViewController;
+            }
 
-			if (root.PresentedViewController != null)
-				return root.PresentedViewController;
-
-			return root;
+            return vc;
 		}
     }
 }


### PR DESCRIPTION
This pull request changes how the current top window is determined in the iOS library. There were some instances where the second top window was returned, instead of the current top window.